### PR TITLE
Run animation frames

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ module.exports = function (config) {
         return promiseLoop(function () {
           return frameCount++ < framesToCapture;
         }, function () {
-          var p = timeHandler.goToTime(browserFrames, delayMs + frameNumToTime(frameCount, framesToCapture));
+          var p = timeHandler.goToTimeAndAnimate(browserFrames, delayMs + frameNumToTime(frameCount, framesToCapture));
           // because this section is run often and there is a small performance
           // penalty of using .then(), we'll limit the use of .then()
           // to only if there's something to do

--- a/lib/immediate-canvas-handler.js
+++ b/lib/immediate-canvas-handler.js
@@ -50,7 +50,7 @@ module.exports = function (config) {
   var canvasMode = capturer.canvasMode;
   var canvasSelector = capturer.canvasSelector;
   var page = config.page;
-  var goToTime = oldGoToTime;
+  var goToTime;
   if (config.alwaysSaveCanvasData) {
     goToTime = function (browserFrames, time) {
       // Goes to a certain time. Can't go backwards
@@ -60,9 +60,11 @@ module.exports = function (config) {
         window._timesnap_canvasData = canvasElement.toDataURL(type);
       }, time, canvasSelector, canvasMode);
     };
+  } else {
+    goToTime = oldGoToTime;
   }
 
-  const goToTimeAndAnimate = function (browserFrames, time) {
+  const goToTimeAndAnimateForCapture = function (browserFrames, time) {
     // Goes to a certain time. Can't go backwards
     return page.evaluate(function (ms, canvasSelector, type) {
       window._processUntilTime(ms);
@@ -72,12 +74,26 @@ module.exports = function (config) {
     }, time, canvasSelector, canvasMode);
   };
 
+  var goToTimeAndAnimate;
+  if (config.alwaysSaveCanvasData) {
+    goToTimeAndAnimate = goToTimeAndAnimateForCapture;
+  } else {
+    goToTimeAndAnimate = function (browserFrames, time) {
+      // Goes to a certain time. Can't go backwards
+      return page.evaluate(function (ms) {
+        window._processUntilTime(ms);
+        window._runAnimationFrames();
+      }, time);
+    };
+  }
+
   return {
     capturer: capturer,
     timeHandler: {
       overwriteTime,
       goToTime,
-      goToTimeAndAnimate
+      goToTimeAndAnimate,
+      goToTimeAndAnimateForCapture
     }
   };
 };

--- a/lib/immediate-canvas-handler.js
+++ b/lib/immediate-canvas-handler.js
@@ -30,8 +30,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-const { overwriteTime } = require('./overwrite-time');
+const timeHandler = require('./overwrite-time');
 const makeCanvasCapturer = require('./make-canvas-capturer');
+
+var overwriteTime = timeHandler.overwriteTime;
+var oldGoToTime = timeHandler.goToTime;
 
 const canvasCapturer = makeCanvasCapturer(function (page) {
   return page.evaluate(function () {
@@ -47,11 +50,23 @@ module.exports = function (config) {
   var canvasMode = capturer.canvasMode;
   var canvasSelector = capturer.canvasSelector;
   var page = config.page;
+  var goToTime = oldGoToTime;
+  if (config.alwaysSaveCanvasData) {
+    goToTime = function (browserFrames, time) {
+      // Goes to a certain time. Can't go backwards
+      return page.evaluate(function (ms, canvasSelector, type) {
+        window._processUntilTime(ms);
+        var canvasElement = document.querySelector(canvasSelector);
+        window._timesnap_canvasData = canvasElement.toDataURL(type);
+      }, time, canvasSelector, canvasMode);
+    };
+  }
 
-  const goToTime = function (browserFrames, time) {
+  const goToTimeAndAnimate = function (browserFrames, time) {
     // Goes to a certain time. Can't go backwards
     return page.evaluate(function (ms, canvasSelector, type) {
       window._processUntilTime(ms);
+      window._runAnimationFrames();
       var canvasElement = document.querySelector(canvasSelector);
       window._timesnap_canvasData = canvasElement.toDataURL(type);
     }, time, canvasSelector, canvasMode);
@@ -61,7 +76,8 @@ module.exports = function (config) {
     capturer: capturer,
     timeHandler: {
       overwriteTime,
-      goToTime
+      goToTime,
+      goToTimeAndAnimate
     }
   };
 };

--- a/lib/overwrite-time.js
+++ b/lib/overwrite-time.js
@@ -186,6 +186,7 @@ const overwriteTime = function (page) {
           clear: function () {
             _clearTimeout(lastCallId);
             running = false;
+            _intervals[id] = null; // dereference for garbage collection
           }
         };
         _idCount++;
@@ -225,8 +226,12 @@ const goToTimeAndAnimate = function (browserFrames, time) {
   }));
 };
 
+const goToTimeAndAnimateForCapture = goToTimeAndAnimate;
+
+
 module.exports = {
   overwriteTime,
   goToTime,
-  goToTimeAndAnimate
+  goToTimeAndAnimate,
+  goToTimeAndAnimateForCapture
 };

--- a/lib/overwrite-time.js
+++ b/lib/overwrite-time.js
@@ -30,8 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-const overwriteTime = function (page, animationFrameDuration) {
-  return page.evaluateOnNewDocument(function (animationFrameDuration) {
+const overwriteTime = function (page) {
+  return page.evaluateOnNewDocument(function () {
     (function (exports) {
       var _virtualTime = (new Date()).getTime();
       var _startTime = _virtualTime;
@@ -60,8 +60,10 @@ const overwriteTime = function (page, animationFrameDuration) {
         block.fn.apply(exports, block.args);
       };
       var _processUntilTime = function (ms) {
+        // We should be careful when iterating through _pendingBlocks,
+        // because other methods (i.e. _sortPendingBlocks and _clearTimeout)
+        // create new references to _pendingBlocks
         _sortPendingBlocks();
-
         while (_pendingBlocks.length && _pendingBlocks[0].time <= _startTime + ms) {
           _processNextBlock();
           _sortPendingBlocks();
@@ -101,38 +103,53 @@ const overwriteTime = function (page, animationFrameDuration) {
         // according to https://developer.mozilla.org/en-US-docs/Web/API/WindowOrWorkerGlobalScope/setInterval,
         // setInterval and setTimeout share the same pool of IDs, and clearInterval and clearTimeout
         // can technically be used interchangeably
-        var i = 0;
         if (_intervals[id]) {
           _intervals[id].clear();
         }
-        while (i < _pendingBlocks.length) {
-          if (_pendingBlocks[i].id === id) {
-            _pendingBlocks.splice(i, 1);
-          } else {
-            i++;
-          }
-        }
+        // We should be careful when creating a new reference for _pendingBlocks,
+        // (e.g. `_pendingBlocks = _pendingBlocks.filter...`), because _clearTimeout
+        // can be called while iterating through _pendingBlocks
+        _pendingBlocks = _pendingBlocks.filter(function (block) {
+          return block.id !== id;
+        });
       };
 
-      var _frameTime;
+      var _animationFrameBlocks = [];
+      var _currentAnimationFrameBlocks = [];
       var _requestAnimationFrame = function (fn) {
-        return _setTimeout(function () {
+        var id = _idCount;
+        _idCount++;
+        _animationFrameBlocks.push({
+          id: id,
+          fn: fn
+        });
+        return id;
+      };
+      var _cancelAnimationFrame = function (id) {
+        _animationFrameBlocks = _animationFrameBlocks.filter(function (block) {
+          return block.id !== id;
+        });
+        _currentAnimationFrameBlocks = _currentAnimationFrameBlocks.filter(function (block) {
+          return block.id !== id;
+        });
+      };
+      var _runAnimationFrames = function () {
+        // since requestAnimationFrame usually adds new frames,
+        // we want to these new ones to be separated from the
+        // currently run frames
+        _currentAnimationFrameBlocks = _animationFrameBlocks;
+        _animationFrameBlocks = [];
+        // We should be careful when iterating through _currentAnimationFrameBlocks,
+        // because _cancelAnimationFrame creates a new reference to _currentAnimationFrameBlocks
+        var block;
+        while (_currentAnimationFrameBlocks.length) {
+          block = _currentAnimationFrameBlocks.shift();
           // According to https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame,
           // the passed argument to the callback should be the starting time of the
-          // chunk of requestAnimationFrame callbacks that are called for that particular frame.
-          // Since the processing time of callbacks do not advance virtual time, in most cases
-          // there may not be significant differences between _frameTime and _virtualTime.
-          fn(_frameTime);
-        }, animationFrameDuration);
+          // chunk of requestAnimationFrame callbacks that are called for that particular frame
+          block.fn(_virtualTime);
+        }
       };
-
-      var _updateFrameTime = function () {
-        // Using this implementation may potentially cause issues in the future
-        // for high-fps capture, where _frameTime is not advanced per frame
-        _requestAnimationFrame(_updateFrameTime);
-        _frameTime = _virtualTime;
-      };
-      _updateFrameTime();
 
       // overwriting built-in functions...
       exports.Date = class Date extends _oldDate {
@@ -178,16 +195,16 @@ const overwriteTime = function (page, animationFrameDuration) {
         // can technically be used interchangeably
         return id;
       };
-      exports.cancelAnimationFrame = _clearTimeout;
+      exports.cancelAnimationFrame = _cancelAnimationFrame;
       exports.clearTimeout = _clearTimeout;
       exports.clearInterval = _clearTimeout;
       // exported custom functions
       exports._processNextBlock = _processNextBlock;
       exports._processUntilTime  = _processUntilTime;
+      exports._runAnimationFrames = _runAnimationFrames;
     })(this);
-  }, animationFrameDuration);
+  });
 };
-
 
 const goToTime = function (browserFrames, time) {
   // Goes to a certain time. Can't go backwards
@@ -198,7 +215,18 @@ const goToTime = function (browserFrames, time) {
   }));
 };
 
+const goToTimeAndAnimate = function (browserFrames, time) {
+  // Goes to a certain time. Can't go backwards
+  return Promise.all(browserFrames.map(function (frame) {
+    return frame.evaluate(function (ms) {
+      window._processUntilTime(ms);
+      window._runAnimationFrames();
+    }, time);
+  }));
+};
+
 module.exports = {
   overwriteTime,
-  goToTime
+  goToTime,
+  goToTimeAndAnimate
 };


### PR DESCRIPTION
Changes the way that `requestAnimationFrame` works.

Before `requestAnimationFrame` worked as a `setTimeout` at an interval determined by frame rate. Now `requestAnimationFrame` separates its callbacks into a different queue that is explicitly run with `_runAnimationFrames`, which is then called every time before capture.

In light of some cases where initialization occurs in the first running of `requestAnimationFrame`, `_runAnimationFrames` is called when there is a significant start delay.

This change may cause some unintended behavior, particularly in cases where there are long deltas (e.g. a low frame rate or a high start delay), and those deltas are then used to determine behavior.

See #10.