### PR TITLE
Jpg support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Opens https://breathejs.org/examples/Drawing-US-Counties.html, sets the viewport
 * <a name="cli-options-screenshot-type" href="#cli-options-screenshot-type">#</a> Screenshot Type: `--screenshot-type` *type*
     * Output image format for the screenshots. By default, the file extension is used to infer type, and failing that, `png` is used. `jpeg` is also available.
 * <a name="cli-options-screenshot-quality" href="#cli-options-screenshot-quality">#</a> Screenshot Quality: `--screenshot-quality` *number*
-    * 1-100 Quality level to be used when screenshot type is 'jpeg'. Currently, puppeteer defaults this to '80'.
+    * Quality level between 0 to 1 for lossy screenshots. Defaults to 0.92 when in [canvas capture mode](#cli-options-canvas-capture-mode) and 0.8 otherwise.
 * <a name="cli-options-start-delay" href="#cli-options-start-delay">#</a> Start Delay: `--start-delay` *n seconds*
     * Waits *n real seconds* after loading the page before starting the virtual timeline.
 * <a name="cli-options-quiet" href="#cli-options-quiet">#</a> Quiet: `-q`, `--quiet`
@@ -273,7 +273,7 @@ The Node API is structured similarly to the command line options, but there are 
     * <a name="js-config-launch-arguments" href="#js-config-launch-arguments">#</a> `launchArguments` &lt;[Array][] &lt;[string][]&gt;&gt; Extra arguments for Puppeteer/Chromium. Example: `['--single-process']`. A list of arguments can be found [here](https://peter.sh/experiments/chromium-command-line-switches).
     * <a name="js-config-headless" href="#js-config-headless">#</a> `headless` &lt;[boolean][]&gt; Runs puppeteer in headless (nonwindowed) mode (default: `true`).
     * <a name="js-config-screenshot-type" href="#js-config-screenshot-type">#</a> `screenshotType` &lt;[string][]&gt; Output image format for the screenshots. By default, the file extension is used to infer type, and failing that, `'png'` is used. `'jpeg'` is also available.
-    * <a name="js-config-screenshot-quality" href="#js-config-screenshot-quality">#</a> `screenshotQuality` &lt;[number][]&gt; 1-100 Quality level to be used when screenshot type is `'jpeg'`. Currently, puppeteer defaults this to '80'.
+    * <a name="js-config-screenshot-quality" href="#js-config-screenshot-quality">#</a> `screenshotQuality` &lt;[number][]&gt; Quality level between 0 to 1 for lossy screenshots. Defaults to 0.92 when in [canvas capture mode](#js-config-canvas-capture-mode) and 0.8 otherwise.
     * <a name="js-config-start-delay" href="#js-config-start-delay">#</a> `startDelay` &lt;[number][]&gt; Waits `config.startDelay` real seconds after loading before starting (default: `0`).
     * <a name="js-config-quiet" href="#js-config-quiet">#</a> `quiet` &lt;[boolean][]&gt; Suppresses console logging.
     * <a name="js-config-log-to-std-err" href="#js-config-log-to-std-err">#</a> `logToStdErr` &lt;[boolean][]&gt; Logs to stderr instead of stdout. Doesn't do anything if `config.quiet` is set to true.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Opens https://breathejs.org/examples/Drawing-US-Counties.html, sets the viewport
 * <a name="cli-options-no-headless" href="#cli-options-no-headless">#</a> No Headless: `--no-headless`
     * Runs Chromium/Chrome in windowed mode.
 * <a name="cli-options-screenshot-type" href="#cli-options-screenshot-type">#</a> Screenshot Type: `--screenshot-type` *type*
-    * Output image format for the screenshots. Puppeteer currently supports 'png' (default) and 'jpeg'.
+    * Output image format for the screenshots. By default, the file extension is used to infer type, and failing that, `png` is used. `jpeg` is also available.
 * <a name="cli-options-screenshot-quality" href="#cli-options-screenshot-quality">#</a> Screenshot Quality: `--screenshot-quality` *number*
     * 1-100 Quality level to be used when screenshot type is 'jpeg'. Currently, puppeteer defaults this to '80'.
 * <a name="cli-options-start-delay" href="#cli-options-start-delay">#</a> Start Delay: `--start-delay` *n seconds*
@@ -272,8 +272,8 @@ The Node API is structured similarly to the command line options, but there are 
      * <a name="js-config-remote-url" href="#js-config-remote-url">#</a> `remoteUrl` &lt;[string][]&gt; URL of remote Chromium/Chrome instance to connect using `puppeteer.connect()`.
     * <a name="js-config-launch-arguments" href="#js-config-launch-arguments">#</a> `launchArguments` &lt;[Array][] &lt;[string][]&gt;&gt; Extra arguments for Puppeteer/Chromium. Example: `['--single-process']`. A list of arguments can be found [here](https://peter.sh/experiments/chromium-command-line-switches).
     * <a name="js-config-headless" href="#js-config-headless">#</a> `headless` &lt;[boolean][]&gt; Runs puppeteer in headless (nonwindowed) mode (default: `true`).
-    * <a name="js-config-screenshot-type" href="#js-config-screenshot-type">#</a> `screenshotType` &lt;[number][]&gt; Output image format for the screenshots. Puppeteer currently supports 'png' (default) and 'jpeg'.
-    * <a name="js-config-screenshot-quality" href="#js-config-screenshot-quality">#</a> `screenshotQuality` &lt;[number][]&gt; 1-100 Quality level to be used when screenshot type is 'jpeg'. Currently, puppeteer defaults this to '80'.
+    * <a name="js-config-screenshot-type" href="#js-config-screenshot-type">#</a> `screenshotType` &lt;[string][]&gt; Output image format for the screenshots. By default, the file extension is used to infer type, and failing that, `'png'` is used. `'jpeg'` is also available.
+    * <a name="js-config-screenshot-quality" href="#js-config-screenshot-quality">#</a> `screenshotQuality` &lt;[number][]&gt; 1-100 Quality level to be used when screenshot type is `'jpeg'`. Currently, puppeteer defaults this to '80'.
     * <a name="js-config-start-delay" href="#js-config-start-delay">#</a> `startDelay` &lt;[number][]&gt; Waits `config.startDelay` real seconds after loading before starting (default: `0`).
     * <a name="js-config-quiet" href="#js-config-quiet">#</a> `quiet` &lt;[boolean][]&gt; Suppresses console logging.
     * <a name="js-config-log-to-std-err" href="#js-config-log-to-std-err">#</a> `logToStdErr` &lt;[boolean][]&gt; Logs to stderr instead of stdout. Doesn't do anything if `config.quiet` is set to true.

--- a/cli.js
+++ b/cli.js
@@ -74,7 +74,7 @@ commander
   })
   .option('--no-headless', 'Chromium/Chrome runs in a window instead of headless mode')
   .option('--screenshot-type <type>', 'Output image format for the screenshots, currently either png or jpeg')
-  .option('--screenshot-quality <level>', 'The quality level to use when screenshot type is jpeg', i => parseInt(i))
+  .option('--screenshot-quality <level>', 'The quality level to use when screenshot type is jpeg', parseFloat)
   .parse(process.argv);
 
 commander.url = commander.args[0] || 'index.html';

--- a/cli.js
+++ b/cli.js
@@ -73,8 +73,8 @@ commander
     return str.split(' ');
   })
   .option('--no-headless', 'Chromium/Chrome runs in a window instead of headless mode')
-  .option('--screenshot-type <type>', 'Output image format for the screenshots, currently either png or jpeg')
-  .option('--screenshot-quality <level>', 'The quality level to use when screenshot type is jpeg', parseFloat)
+  .option('--screenshot-type <type>', 'Output image format for screenshots, either png or jpeg')
+  .option('--screenshot-quality <level>', 'The quality level for lossy screenshots', parseFloat)
   .parse(process.argv);
 
 commander.url = commander.args[0] || 'index.html';

--- a/lib/capture-canvas.js
+++ b/lib/capture-canvas.js
@@ -32,11 +32,11 @@
 
 const makeCanvasCapturer = require('./make-canvas-capturer');
 
-const canvasToBuffer = function (page, canvasSelector, type) {
-  return page.evaluate(function (canvasSelector, type) {
+const canvasToBuffer = function (page, canvasSelector, type, quality) {
+  return page.evaluate(function (canvasSelector, type, quality) {
     var canvasElement = document.querySelector(canvasSelector);
-    return canvasElement.toDataURL(type);
-  }, canvasSelector, type).then(function (dataUrl) {
+    return canvasElement.toDataURL(type, quality);
+  }, canvasSelector, type, quality).then(function (dataUrl) {
     var data = dataUrl.slice(dataUrl.indexOf(',') + 1);
     return new Buffer(data, 'base64');
   });

--- a/lib/capture-screenshot.js
+++ b/lib/capture-screenshot.js
@@ -91,12 +91,19 @@ module.exports = function (config) {
     },
     capture: function (sameConfig, frameCount, framesToCapture) {
       var filePath = filePathConverter(frameCount, framesToCapture);
+      var screenshotType = config.screenshotType;
       if (filePath) {
         makeFileDirectoryIfNeeded(filePath);
+        if (!screenshotType) {
+          // autodetect screenshot type
+          if (filePath.toLowerCase().endsWith('.jpg') || filePath.toLowerCase().endsWith('.jpeg')) {
+            screenshotType = 'jpeg';
+          }
+        }
       }
       log('Capturing Frame ' + frameCount + (filePath ? ' to ' + filePath : '') + '...');
       var p = page.screenshot({
-        type: config.screenshotType,
+        type: screenshotType,
         quality: config.screenshotQuality,
         path: filePath,
         clip: screenshotClip,

--- a/lib/capture-screenshot.js
+++ b/lib/capture-screenshot.js
@@ -96,7 +96,7 @@ module.exports = function (config) {
       }
       log('Capturing Frame ' + frameCount + (filePath ? ' to ' + filePath : '') + '...');
       var p = page.screenshot({
-        type: config.sreenshotType,
+        type: config.screenshotType,
         quality: config.screenshotQuality,
         path: filePath,
         clip: screenshotClip,

--- a/lib/capture-screenshot.js
+++ b/lib/capture-screenshot.js
@@ -97,7 +97,7 @@ module.exports = function (config) {
       log('Capturing Frame ' + frameCount + (filePath ? ' to ' + filePath : '') + '...');
       var p = page.screenshot({
         type: config.screenshotType,
-        quality: (config.screenshotQuality || 0) * 100,
+        quality: typeof config.screenshotQuality === 'number' ? config.screenshotQuality * 100 : config.screenshotQuality,
         path: filePath,
         clip: screenshotClip,
         omitBackground: config.transparentBackground ? true : false

--- a/lib/capture-screenshot.js
+++ b/lib/capture-screenshot.js
@@ -97,7 +97,7 @@ module.exports = function (config) {
       log('Capturing Frame ' + frameCount + (filePath ? ' to ' + filePath : '') + '...');
       var p = page.screenshot({
         type: config.screenshotType,
-        quality: config.screenshotQuality,
+        quality: (config.screenshotQuality || 0) * 100,
         path: filePath,
         clip: screenshotClip,
         omitBackground: config.transparentBackground ? true : false

--- a/lib/capture-screenshot.js
+++ b/lib/capture-screenshot.js
@@ -91,19 +91,12 @@ module.exports = function (config) {
     },
     capture: function (sameConfig, frameCount, framesToCapture) {
       var filePath = filePathConverter(frameCount, framesToCapture);
-      var screenshotType = config.screenshotType;
       if (filePath) {
         makeFileDirectoryIfNeeded(filePath);
-        if (!screenshotType) {
-          // autodetect screenshot type
-          if (filePath.toLowerCase().endsWith('.jpg') || filePath.toLowerCase().endsWith('.jpeg')) {
-            screenshotType = 'jpeg';
-          }
-        }
       }
       log('Capturing Frame ' + frameCount + (filePath ? ' to ' + filePath : '') + '...');
       var p = page.screenshot({
-        type: screenshotType,
+        type: config.screenshotType,
         quality: config.screenshotQuality,
         path: filePath,
         clip: screenshotClip,

--- a/lib/immediate-canvas-handler.js
+++ b/lib/immediate-canvas-handler.js
@@ -49,16 +49,17 @@ module.exports = function (config) {
   var capturer = canvasCapturer(config);
   var canvasCaptureMode = capturer.canvasCaptureMode;
   var canvasSelector = capturer.canvasSelector;
+  var quality = capturer.quality;
   var page = config.page;
   var goToTime;
   if (config.alwaysSaveCanvasData) {
     goToTime = function (browserFrames, time) {
       // Goes to a certain time. Can't go backwards
-      return page.evaluate(function (ms, canvasSelector, type) {
+      return page.evaluate(function (ms, canvasSelector, type, quality) {
         window._timesnap_processUntilTime(ms);
         var canvasElement = document.querySelector(canvasSelector);
-        window._timesnap_canvasData = canvasElement.toDataURL(type);
-      }, time, canvasSelector, canvasCaptureMode);
+        window._timesnap_canvasData = canvasElement.toDataURL(type, quality);
+      }, time, canvasSelector, canvasCaptureMode, quality);
     };
   } else {
     goToTime = oldGoToTime;
@@ -66,14 +67,14 @@ module.exports = function (config) {
 
   const goToTimeAndAnimateForCapture = function (browserFrames, time) {
     // Goes to a certain time. Can't go backwards
-    return page.evaluate(function (ms, canvasSelector, type) {
+    return page.evaluate(function (ms, canvasSelector, type, quality) {
       window._timesnap_processUntilTime(ms);
       return window._timesnap_runFramePreparers(ms, function () {
         window._timesnap_runAnimationFrames();
         var canvasElement = document.querySelector(canvasSelector);
-        window._timesnap_canvasData = canvasElement.toDataURL(type);
+        window._timesnap_canvasData = canvasElement.toDataURL(type, quality);
       });
-    }, time, canvasSelector, canvasCaptureMode);
+    }, time, canvasSelector, canvasCaptureMode, quality);
   };
 
   var goToTimeAndAnimate;

--- a/lib/make-canvas-capturer.js
+++ b/lib/make-canvas-capturer.js
@@ -46,8 +46,9 @@ module.exports = function makeCanvasCapturer(canvasToBuffer) {
     var pendingWritePromises = [];
     var waitForWriting = false;
     var framesToCapture = config.framesToCapture;
+    var quality = config.screenshotQuality;
     var filePath = filePathConverter(1, framesToCapture);
-    if (typeof canvasCaptureMode !== 'string') {
+    if (typeof canvasCaptureMode !== 'string' || !canvasCaptureMode) {
       canvasCaptureMode = config.screenshotType;
       if (!canvasCaptureMode && filePath) {
         canvasCaptureMode = path.extname(filePath).substring(1);
@@ -65,10 +66,11 @@ module.exports = function makeCanvasCapturer(canvasToBuffer) {
     return {
       canvasCaptureMode,
       canvasSelector,
+      quality,
       capture: function (sameConfig, frameCount) {
         filePath = filePathConverter(frameCount, framesToCapture);
         log('Capturing Frame ' + frameCount + (filePath ? ' to ' + filePath : '') + '...');
-        var p = canvasToBuffer(page, canvasSelector, canvasCaptureMode);
+        var p = canvasToBuffer(page, canvasSelector, canvasCaptureMode, quality);
         if (filePath) {
           p = p.then(function (buffer) {
             var writePromise = writeFile(filePath, buffer);

--- a/lib/make-canvas-capturer.js
+++ b/lib/make-canvas-capturer.js
@@ -47,14 +47,20 @@ module.exports = function makeCanvasCapturer(canvasToBuffer) {
     var waitForWriting = false;
     var framesToCapture = config.framesToCapture;
     var filePath = filePathConverter(1, framesToCapture);
-    if (filePath && typeof canvasCaptureMode !== 'string') {
-      canvasCaptureMode = path.extname(filePath).substring(1);
-    }
     if (typeof canvasCaptureMode !== 'string') {
-      canvasCaptureMode = defaultCanvasCaptureMode;
+      canvasCaptureMode = config.screenshotType;
+      if (!canvasCaptureMode && filePath) {
+        canvasCaptureMode = path.extname(filePath).substring(1);
+      }
+      if (!canvasCaptureMode) {
+        canvasCaptureMode = defaultCanvasCaptureMode;
+      }
     }
     if (!canvasCaptureMode.startsWith('image/')) {
       canvasCaptureMode = 'image/' + canvasCaptureMode;
+    }
+    if (canvasCaptureMode === 'image/jpg') {
+      canvasCaptureMode = 'image/jpeg';
     }
     return {
       canvasCaptureMode,


### PR DESCRIPTION
Adds support for explicitly specifying file formats (including jpg) for puppeteer screenshot capture. Previously, the format was inferred by puppeteer based on the output file extension. Useful for cases where an output file is not specified (piping, for instance).

Also adds support for specifying screenshot quality.