### PR TITLE
Add support for skip current frame

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,32 +256,38 @@ module.exports = function (config) {
             // penalty of using .then(), we'll limit the use of .then()
             // to only if there's something to do
 
-            if (config.skipScreenshot) {
+            var skipCurrentFrame;
+
+            if (config.shouldSkipFrame) {
               p = p.then(function () {
-                return config.skipScreenshot(page, marker.data.frameCount, framesToCapture);
+                skipCurrentFrame = config.shouldSkipFrame({
+                  page: page,
+                  frameCount: marker.data.frameCount,
+                  framesToCapture: framesToCapture
+                });
               })
             }
 
             if (config.preparePageForScreenshot) {
-              p = p.then(function (skipCurrentFrame = false) {
-                if (skipCurrentFrame === true) {  
-                  return skipCurrentFrame;
+              p = p.then(function () {
+                if (skipCurrentFrame) {
+                  log('Skipping frame: ' + marker.data.frameCount);
+                  return;
                 }
 
                 log('Preparing page for screenshot...');
                 return config.preparePageForScreenshot(page, marker.data.frameCount, framesToCapture);
-              }).then(function (skipCurrentFrame = false) {
-                if (skipCurrentFrame === true) {
-                  return skipCurrentFrame;
+              }).then(function () {
+                if (skipCurrentFrame) {
+                  return;
                 }
 
                 log('Page prepared');
               });
             }
             if (capturer.capture) {
-              p = p.then(function (skipCurrentFrame = false) {
-                if (skipCurrentFrame) {
-                  log('Skip screenshot for frame: ' + marker.data.frameCount);
+              p = p.then(function () {
+                if (skipCurrentFrame) {  
                   return;
                 }
 

--- a/index.js
+++ b/index.js
@@ -248,6 +248,7 @@ module.exports = function (config) {
         }, function () {
           var marker = markers[markerIndex];
           var p;
+          var skipFrame = false;
           markerIndex++;
           if (marker.type === 'Capture') {
             p = timeHandler.goToTimeAndAnimateForCapture(browserFrames, marker.time);
@@ -258,12 +259,22 @@ module.exports = function (config) {
               p = p.then(function () {
                 log('Preparing page for screenshot...');
                 return config.preparePageForScreenshot(page, marker.data.frameCount, framesToCapture);
-              }).then(function () {
-                log('Page prepared');
+              }).then(function (skipCurrentFrame = false) {
+                skipFrame = skipCurrentFrame;
+
+                if (skipCurrentFrame) {
+                  log('Frame is skipped');
+                } else {
+                  log('Page prepared');
+                }
               });
             }
             if (capturer.capture) {
               p = p.then(function () {
+                if (skipFrame) {
+                  return;
+                }
+
                 return capturer.capture(config, marker.data.frameCount, framesToCapture);
               });
             }


### PR DESCRIPTION
If you want to skip specific frames, for example every other frame:

```javascript
timesnapConfig.preparePageForScreenshot = (page, currentFrame, totalFrame) => {
  return Promise.resolve(currentFrame % 2 === 0)
}
```

It is our solution to this issue #8. we used multiple instances of timesnap for faster rendering, by letting every instance capture a fraction of the frames.

A simple page with an animation of 60 frames takes ~6000ms instead of ~19000ms, using three timesnap instances.