### PR TITLE
Add support for external log transporters

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,8 +87,8 @@ module.exports = function (config) {
 
   const log = function () {
     if (!config.quiet) {
-      if (config.hasOwnProperty('logTransporter') && typeof config.logTransporter === 'function') {
-        config.logTransporter(arguments);
+      if (config.logger) {
+        config.logger(...arguments);
       } else if (config.logToStdErr) {
         // eslint-disable-next-line no-console
         console.error.apply(this, arguments);

--- a/index.js
+++ b/index.js
@@ -87,7 +87,9 @@ module.exports = function (config) {
 
   const log = function () {
     if (!config.quiet) {
-      if (config.logToStdErr) {
+      if (config.hasOwnProperty('logTransporter') && typeof config.logTransporter === 'function') {
+        config.logTransporter(arguments);
+      } else if (config.logToStdErr) {
         // eslint-disable-next-line no-console
         console.error.apply(this, arguments);
       } else {


### PR DESCRIPTION
Added support for external log transporter like if you want to log data from timesnap inside your node application.

```javascript
timesnapConfig.logTransporter = (args) => {
  // store to db functionality
}
```
