### PR TITLE
fix: fix overriding device scale factor

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,14 +151,25 @@ module.exports = function (config) {
         log('Capture Mode: Screenshot');
       }
       return Promise.resolve().then(function () {
-        if (config.viewport) {
-          if (!config.viewport.width) {
-            config.viewport.width = page.viewport().width;
-          }
-          if (!config.viewport.height) {
-            config.viewport.height = page.viewport().height;
-          }
-          return page.setViewport(config.viewport);
+        var scaleArg = launchOptions.args.find(function (arg){
+          return arg.indexOf('--force-device-scale-factor') > -1;
+        }) || launchOptions.args.find(function (arg){
+          return arg.indexOf('--device-scale-factor') > -1;
+        });
+        var deviceScaleFactor = scaleArg ? Number(scaleArg.split('=')[1]) || 1 : 1;
+
+        if (config.viewport || scaleArg) {
+          var defaultViewPort = {
+            width: page.viewport().width,
+            height: page.viewport().height,
+          };
+
+          config.viewport = Object.assign(
+            defaultViewPort,
+            config.viewport,
+            { deviceScaleFactor }
+          );
+          return page.setViewport(config.viewport);  
         }
       }).then(function () {
         return overwriteRandom(page, unrandom, log);


### PR DESCRIPTION
Setting viewport was overriding puppeteer `launchOptions` that set device scale factor 
https://github.com/tungs/timesnap/blob/master/index.js#L161

this does not allow improving image quality by setting `--launch-arguments="--device-scale-factor=2"`, or alternatively `--launch-arguments="--force-device-scale-factor=2"`, as mentioned in #30 

This fixes it by extracting these options and adding them to config.viewport

You may consider also doing that for the rest of the properties
https://pptr.dev/#?product=Puppeteer&version=v5.0.0&show=api-pagesetviewportviewport

I believe this is an important setting for image quality, so you may also consider making it a cli arg 